### PR TITLE
Quiet readasap3 dat file

### DIFF
--- a/R/read_ASAP3_dat_file.R
+++ b/R/read_ASAP3_dat_file.R
@@ -4,7 +4,7 @@
 #' @param datf full path and name of dat file (including .dat suffix)
 #' @export
 
-ReadASAP3DatFile <- function(datf){
+ReadASAP3DatFile <- function(datf, quiet_opt=FALSE){
 
   ### Read in file
   char.lines <- readLines(datf)
@@ -28,174 +28,174 @@ ReadASAP3DatFile <- function(datf){
   dat <- list()
   ind <- 0
 
-  dat$n_years <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
+  dat$n_years <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
     # Within the skip fx, n represents the maximum number of data values to be read
     # So for the above scan call, we are skipping 6 lines (dat.start[1] = 6) and reading in 1 integer
-  dat$year1 <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$n_ages <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$n_fleets <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$n_fleet_sel_blocks <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
+  dat$year1 <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$n_ages <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$n_fleets <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$n_fleet_sel_blocks <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
     # Number of selectivity blocks (across all fleets)
-  dat$n_indices <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
+  dat$n_indices <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
 
-  dat$M <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_ages), dat$n_years, dat$n_ages, byrow = TRUE)
-  dat$fec_opt <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$fracyr_spawn <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$maturity <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_ages), dat$n_years, dat$n_ages, byrow = TRUE)
-  dat$n_WAA_mats <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
+  dat$M <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_ages, quiet=quiet_opt), dat$n_years, dat$n_ages, byrow = TRUE)
+  dat$fec_opt <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$fracyr_spawn <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$maturity <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_ages, quiet=quiet_opt), dat$n_years, dat$n_ages, byrow = TRUE)
+  dat$n_WAA_mats <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
     # at this point, nind = 11
-  dat$WAA_mats <- lapply(1:dat$n_WAA_mats, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = dat$n_years*dat$n_ages), dat$n_years, dat$n_ages, byrow = TRUE))
+  dat$WAA_mats <- lapply(1:dat$n_WAA_mats, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = dat$n_years*dat$n_ages, quiet=quiet_opt), dat$n_years, dat$n_ages, byrow = TRUE))
     ind <- ind+dat$n_WAA_mats
     # Updated ind after reading in the WAA matrices;  if there are 3 WAA matrices, nind now = 14
 
 
   ### Number of WAA Pointers
   npt <- dat$n_fleets * 2 + 2 + 2
-  dat$WAA_pointers <- as.matrix(sapply(1:npt, function(x) scan(datf, what = integer(), skip = dat.start[ind+1]+x-1, n = 1)))
+  dat$WAA_pointers <- as.matrix(sapply(1:npt, function(x) scan(datf, what = integer(), skip = dat.start[ind+1]+x-1, n = 1, quiet=quiet_opt)))
     ind <- ind + 1
     # Regardless of # of WAA pointers, nind only increases by one because all WAA pointers are within a single vector
 
 
   ### Selectivity block assignment and parameters
-  dat$sel_block_assign <- lapply(1:dat$n_fleets, function(x) scan(datf, what = integer(), skip = dat.start[ind+x], n = dat$n_years))
+  dat$sel_block_assign <- lapply(1:dat$n_fleets, function(x) scan(datf, what = integer(), skip = dat.start[ind+x], n = dat$n_years, quiet=quiet_opt))
     ind <- ind+dat$n_fleets
   ### Selectivity options for each block
-  dat$sel_block_option <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_fleet_sel_blocks)
+  dat$sel_block_option <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_fleet_sel_blocks, quiet=quiet_opt)
     # ind check
         # print(ind);  print(dat.start[ind]);
-  dat$sel_ini <- lapply(1:dat$n_fleet_sel_blocks, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = 4*(dat$n_ages+6)), dat$n_ages+6, 4, byrow = TRUE))
+  dat$sel_ini <- lapply(1:dat$n_fleet_sel_blocks, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = 4*(dat$n_ages+6), quiet=quiet_opt), dat$n_ages+6, 4, byrow = TRUE))
     ind <- ind + dat$n_fleet_sel_blocks
-  dat$fleet_sel_start_age <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets)
-  dat$fleet_sel_end_age <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets)
+  dat$fleet_sel_start_age <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet_opt)
+  dat$fleet_sel_end_age <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet_opt)
 
-  dat$Frep_ages <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 2)
-  dat$Frep_type <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$use_like_const <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$release_mort <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets)
+  dat$Frep_ages <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 2, quiet=quiet_opt)
+  dat$Frep_type <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$use_like_const <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$release_mort <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet_opt)
 
 
   ### Catch and discards
-  dat$CAA_mats <- lapply(1:dat$n_fleets, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = dat$n_years*(dat$n_ages+1)), dat$n_years, dat$n_ages+1, byrow = TRUE))
+  dat$CAA_mats <- lapply(1:dat$n_fleets, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = dat$n_years*(dat$n_ages+1), quiet=quiet_opt), dat$n_years, dat$n_ages+1, byrow = TRUE))
     ind <- ind + dat$n_fleets
-  dat$DAA_mats <- lapply(1:dat$n_fleets, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = dat$n_years*(dat$n_ages+1)), dat$n_years, dat$n_ages+1, byrow = TRUE))
+  dat$DAA_mats <- lapply(1:dat$n_fleets, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = dat$n_years*(dat$n_ages+1), quiet=quiet_opt), dat$n_years, dat$n_ages+1, byrow = TRUE))
     ind <- ind + dat$n_fleets
-  dat$prop_rel_mats <- lapply(1:dat$n_fleets, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = dat$n_years*(dat$n_ages)), dat$n_years, dat$n_ages, byrow = TRUE))
+  dat$prop_rel_mats <- lapply(1:dat$n_fleets, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = dat$n_years*(dat$n_ages), quiet=quiet_opt), dat$n_years, dat$n_ages, byrow = TRUE))
     ind <- ind + dat$n_fleets
 
 
   ### Survey index specifications
-  dat$index_units <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices)
-  dat$index_acomp_units <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices)
-  dat$index_WAA_pointers <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices)
-  dat$index_month <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices)
-  dat$index_sel_choice <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices)
-  dat$index_sel_option <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices)
-  dat$index_sel_start_age <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices)
-  dat$index_sel_end_age <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices)
-  dat$use_index_acomp <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices)
-  dat$use_index <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices)
+  dat$index_units <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
+  dat$index_acomp_units <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
+  dat$index_WAA_pointers <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
+  dat$index_month <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
+  dat$index_sel_choice <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
+  dat$index_sel_option <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
+  dat$index_sel_start_age <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
+  dat$index_sel_end_age <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
+  dat$use_index_acomp <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
+  dat$use_index <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
 
 
   ### Survey index selectivity
-  dat$index_sel_ini <- lapply(1:dat$n_indices, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = 4*(dat$n_ages+6)), dat$n_ages+6, 4, byrow = TRUE))
+  dat$index_sel_ini <- lapply(1:dat$n_indices, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = 4*(dat$n_ages+6), quiet=quiet_opt), dat$n_ages+6, 4, byrow = TRUE))
     ind <- ind + dat$n_indices
 
 
   ### Survey index data matrices
     # Columns are: [Year, Value, CV, 1:nage, Sample Size]
-  dat$IAA_mats <- lapply(1:dat$n_indices, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = dat$n_years*(dat$n_ages+4)), dat$n_years, dat$n_ages+4, byrow = TRUE))
+  dat$IAA_mats <- lapply(1:dat$n_indices, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = dat$n_years*(dat$n_ages+4), quiet=quiet_opt), dat$n_years, dat$n_ages+4, byrow = TRUE))
     ind <- ind + dat$n_indices
 
 
   ### Phases
-  dat$phase_F1 <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$phase_F_devs <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$phase_rec_devs <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$phase_N1_devs <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$phase_q <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$phase_q_devs <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$phase_SR_scalar <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$phase_steepness <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
+  dat$phase_F1 <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$phase_F_devs <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$phase_rec_devs <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$phase_N1_devs <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$phase_q <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$phase_q_devs <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$phase_SR_scalar <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$phase_steepness <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
 
 
   ### CVs and Lambdas
   # .... related to recruitment
-  dat$recruit_cv <- as.matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years))
+  dat$recruit_cv <- as.matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years, quiet=quiet_opt))
   # .... related to catch, discrads and indices
-  dat$lambda_index <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices)
-  dat$lambda_catch <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets)
-  dat$lambda_discard <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets)
-  dat$catch_cv <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_fleets), dat$n_years, dat$n_fleets, byrow = TRUE)
-  dat$discard_cv <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_fleets), dat$n_years, dat$n_fleets, byrow = TRUE)
-  dat$catch_Neff <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_fleets), dat$n_years, dat$n_fleets, byrow = TRUE)
-  dat$discard_Neff <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_fleets), dat$n_years, dat$n_fleets, byrow = TRUE)
+  dat$lambda_index <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
+  dat$lambda_catch <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet_opt)
+  dat$lambda_discard <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet_opt)
+  dat$catch_cv <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_fleets, quiet=quiet_opt), dat$n_years, dat$n_fleets, byrow = TRUE)
+  dat$discard_cv <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_fleets, quiet=quiet_opt), dat$n_years, dat$n_fleets, byrow = TRUE)
+  dat$catch_Neff <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_fleets, quiet=quiet_opt), dat$n_years, dat$n_fleets, byrow = TRUE)
+  dat$discard_Neff <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_fleets, quiet=quiet_opt), dat$n_years, dat$n_fleets, byrow = TRUE)
   # .... related to fishing mortality
-  dat$lambda_F1 <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets)
-  dat$cv_F1 <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets)
-  dat$lambda_F_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets)
-  dat$cv_F_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets)
+  dat$lambda_F1 <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet_opt)
+  dat$cv_F1 <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet_opt)
+  dat$lambda_F_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet_opt)
+  dat$cv_F_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet_opt)
   # .... related to abundance (and recruitment again)
-  dat$lambda_N1_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$cv_N1_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$lambda_rec_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1)
+  dat$lambda_N1_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$cv_N1_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$lambda_rec_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
   # .... related to catchability
-  dat$lambda_q <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices)
-  dat$cv_q <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices)
-  dat$lambda_q_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices)
-  dat$cv_q_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices)
+  dat$lambda_q <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
+  dat$cv_q <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
+  dat$lambda_q_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
+  dat$cv_q_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
   # .... related to S-R relationship
-  dat$lambda_steepness <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$cv_steepness <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$lambda_SR_scalar <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$cv_SR_scalar <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1)
+  dat$lambda_steepness <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$cv_steepness <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$lambda_SR_scalar <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$cv_SR_scalar <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
 
 
   ### Initial guesses
-  dat$N1_flag <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
+  dat$N1_flag <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
     # 1 for devs from exponential decline, 2 for devs from initial guesses
-  dat$N1_ini <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_ages)
-  dat$F1_ini <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets)
-  dat$q_ini <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices)
-  dat$SR_scalar_type <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
+  dat$N1_ini <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_ages, quiet=quiet_opt)
+  dat$F1_ini <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet_opt)
+  dat$q_ini <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
+  dat$SR_scalar_type <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
     # 1 for R0, 0 for SSB0
-  dat$SR_scalar_ini <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$steepness_ini <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$Fmax <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$ignore_guesses <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
+  dat$SR_scalar_ini <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$steepness_ini <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$Fmax <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$ignore_guesses <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
 
 
   ### Projections
-  dat$do_proj <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$dir_fleet <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets)
-  dat$nfinalyear <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
+  dat$do_proj <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$dir_fleet <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet_opt)
+  dat$nfinalyear <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
   # .... number of years in projections
   n <- (dat$nfinalyear-dat$year1)-dat$n_years+1
   # .... projection data by year (if n>0)
-  if(n>0) { dat$proj_ini <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = n*5), n, 5, byrow = TRUE) }  else
+  if(n>0) { dat$proj_ini <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = n*5, quiet=quiet_opt), n, 5, byrow = TRUE) }  else
       dat$proj_ini <- matrix(nrow = 0, ncol = 5)
     # be careful here, may cause problems writing because no lines when final year of projection=last year in assessment
 
 
   ### MCMC
-  dat$doMCMC <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$MCMC_nyear_opt <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
+  dat$doMCMC <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$MCMC_nyear_opt <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
     # 0=output nyear NAA, 1=output nyear+1 NAA
-  dat$MCMC_nboot <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$MCMC_nthin <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$MCMC_nseed <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
+  dat$MCMC_nboot <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$MCMC_nthin <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$MCMC_nseed <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
   # .... agepro
-  dat$fill_R_opt <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
+  dat$fill_R_opt <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
     # 1=SR, 2=geomean
-  dat$R_avg_start <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$R_avg_end <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
+  dat$R_avg_start <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$R_avg_end <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
 
 
   ### Final loose ends
-  dat$make_R_file <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
-  dat$testval <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1)
+  dat$make_R_file <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$testval <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
 
   if(dat$testval != -23456)  {stop("dat file not read in correctly because testval does not equal -23456")}
-  if(dat$testval == -23456)  {print("Hooray!  Test value at end of file is correct")}
+  if(dat$testval == -23456)  {print("Hooray!  Test value at end of file is correct.  dat file read in correctly by ReadASAP3DatFile.")}
 
 
   ### Survey and fleet names

--- a/R/read_ASAP3_dat_file.R
+++ b/R/read_ASAP3_dat_file.R
@@ -4,7 +4,7 @@
 #' @param datf full path and name of dat file (including .dat suffix)
 #' @export
 
-ReadASAP3DatFile <- function(datf, quiet_opt=FALSE){
+ReadASAP3DatFile <- function(datf, quiet=FALSE){
 
   ### Read in file
   char.lines <- readLines(datf)
@@ -28,171 +28,171 @@ ReadASAP3DatFile <- function(datf, quiet_opt=FALSE){
   dat <- list()
   ind <- 0
 
-  dat$n_years <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$n_years <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
     # Within the skip fx, n represents the maximum number of data values to be read
     # So for the above scan call, we are skipping 6 lines (dat.start[1] = 6) and reading in 1 integer
-  dat$year1 <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$n_ages <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$n_fleets <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$n_fleet_sel_blocks <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$year1 <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$n_ages <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$n_fleets <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$n_fleet_sel_blocks <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
     # Number of selectivity blocks (across all fleets)
-  dat$n_indices <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$n_indices <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
 
-  dat$M <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_ages, quiet=quiet_opt), dat$n_years, dat$n_ages, byrow = TRUE)
-  dat$fec_opt <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$fracyr_spawn <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$maturity <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_ages, quiet=quiet_opt), dat$n_years, dat$n_ages, byrow = TRUE)
-  dat$n_WAA_mats <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$M <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_ages, quiet=quiet), dat$n_years, dat$n_ages, byrow = TRUE)
+  dat$fec_opt <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$fracyr_spawn <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$maturity <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_ages, quiet=quiet), dat$n_years, dat$n_ages, byrow = TRUE)
+  dat$n_WAA_mats <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
     # at this point, nind = 11
-  dat$WAA_mats <- lapply(1:dat$n_WAA_mats, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = dat$n_years*dat$n_ages, quiet=quiet_opt), dat$n_years, dat$n_ages, byrow = TRUE))
+  dat$WAA_mats <- lapply(1:dat$n_WAA_mats, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = dat$n_years*dat$n_ages, quiet=quiet), dat$n_years, dat$n_ages, byrow = TRUE))
     ind <- ind+dat$n_WAA_mats
     # Updated ind after reading in the WAA matrices;  if there are 3 WAA matrices, nind now = 14
 
 
   ### Number of WAA Pointers
   npt <- dat$n_fleets * 2 + 2 + 2
-  dat$WAA_pointers <- as.matrix(sapply(1:npt, function(x) scan(datf, what = integer(), skip = dat.start[ind+1]+x-1, n = 1, quiet=quiet_opt)))
+  dat$WAA_pointers <- as.matrix(sapply(1:npt, function(x) scan(datf, what = integer(), skip = dat.start[ind+1]+x-1, n = 1, quiet=quiet)))
     ind <- ind + 1
     # Regardless of # of WAA pointers, nind only increases by one because all WAA pointers are within a single vector
 
 
   ### Selectivity block assignment and parameters
-  dat$sel_block_assign <- lapply(1:dat$n_fleets, function(x) scan(datf, what = integer(), skip = dat.start[ind+x], n = dat$n_years, quiet=quiet_opt))
+  dat$sel_block_assign <- lapply(1:dat$n_fleets, function(x) scan(datf, what = integer(), skip = dat.start[ind+x], n = dat$n_years, quiet=quiet))
     ind <- ind+dat$n_fleets
   ### Selectivity options for each block
-  dat$sel_block_option <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_fleet_sel_blocks, quiet=quiet_opt)
+  dat$sel_block_option <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_fleet_sel_blocks, quiet=quiet)
     # ind check
         # print(ind);  print(dat.start[ind]);
-  dat$sel_ini <- lapply(1:dat$n_fleet_sel_blocks, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = 4*(dat$n_ages+6), quiet=quiet_opt), dat$n_ages+6, 4, byrow = TRUE))
+  dat$sel_ini <- lapply(1:dat$n_fleet_sel_blocks, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = 4*(dat$n_ages+6), quiet=quiet), dat$n_ages+6, 4, byrow = TRUE))
     ind <- ind + dat$n_fleet_sel_blocks
-  dat$fleet_sel_start_age <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet_opt)
-  dat$fleet_sel_end_age <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet_opt)
+  dat$fleet_sel_start_age <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet)
+  dat$fleet_sel_end_age <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet)
 
-  dat$Frep_ages <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 2, quiet=quiet_opt)
-  dat$Frep_type <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$use_like_const <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$release_mort <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet_opt)
+  dat$Frep_ages <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 2, quiet=quiet)
+  dat$Frep_type <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$use_like_const <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$release_mort <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet)
 
 
   ### Catch and discards
-  dat$CAA_mats <- lapply(1:dat$n_fleets, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = dat$n_years*(dat$n_ages+1), quiet=quiet_opt), dat$n_years, dat$n_ages+1, byrow = TRUE))
+  dat$CAA_mats <- lapply(1:dat$n_fleets, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = dat$n_years*(dat$n_ages+1), quiet=quiet), dat$n_years, dat$n_ages+1, byrow = TRUE))
     ind <- ind + dat$n_fleets
-  dat$DAA_mats <- lapply(1:dat$n_fleets, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = dat$n_years*(dat$n_ages+1), quiet=quiet_opt), dat$n_years, dat$n_ages+1, byrow = TRUE))
+  dat$DAA_mats <- lapply(1:dat$n_fleets, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = dat$n_years*(dat$n_ages+1), quiet=quiet), dat$n_years, dat$n_ages+1, byrow = TRUE))
     ind <- ind + dat$n_fleets
-  dat$prop_rel_mats <- lapply(1:dat$n_fleets, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = dat$n_years*(dat$n_ages), quiet=quiet_opt), dat$n_years, dat$n_ages, byrow = TRUE))
+  dat$prop_rel_mats <- lapply(1:dat$n_fleets, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = dat$n_years*(dat$n_ages), quiet=quiet), dat$n_years, dat$n_ages, byrow = TRUE))
     ind <- ind + dat$n_fleets
 
 
   ### Survey index specifications
-  dat$index_units <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
-  dat$index_acomp_units <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
-  dat$index_WAA_pointers <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
-  dat$index_month <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
-  dat$index_sel_choice <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
-  dat$index_sel_option <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
-  dat$index_sel_start_age <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
-  dat$index_sel_end_age <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
-  dat$use_index_acomp <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
-  dat$use_index <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
+  dat$index_units <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet)
+  dat$index_acomp_units <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet)
+  dat$index_WAA_pointers <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet)
+  dat$index_month <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet)
+  dat$index_sel_choice <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet)
+  dat$index_sel_option <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet)
+  dat$index_sel_start_age <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet)
+  dat$index_sel_end_age <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet)
+  dat$use_index_acomp <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet)
+  dat$use_index <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet)
 
 
   ### Survey index selectivity
-  dat$index_sel_ini <- lapply(1:dat$n_indices, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = 4*(dat$n_ages+6), quiet=quiet_opt), dat$n_ages+6, 4, byrow = TRUE))
+  dat$index_sel_ini <- lapply(1:dat$n_indices, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = 4*(dat$n_ages+6), quiet=quiet), dat$n_ages+6, 4, byrow = TRUE))
     ind <- ind + dat$n_indices
 
 
   ### Survey index data matrices
     # Columns are: [Year, Value, CV, 1:nage, Sample Size]
-  dat$IAA_mats <- lapply(1:dat$n_indices, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = dat$n_years*(dat$n_ages+4), quiet=quiet_opt), dat$n_years, dat$n_ages+4, byrow = TRUE))
+  dat$IAA_mats <- lapply(1:dat$n_indices, function(x) matrix(scan(datf, what = double(), skip = dat.start[ind+x], n = dat$n_years*(dat$n_ages+4), quiet=quiet), dat$n_years, dat$n_ages+4, byrow = TRUE))
     ind <- ind + dat$n_indices
 
 
   ### Phases
-  dat$phase_F1 <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$phase_F_devs <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$phase_rec_devs <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$phase_N1_devs <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$phase_q <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$phase_q_devs <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$phase_SR_scalar <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$phase_steepness <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$phase_F1 <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$phase_F_devs <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$phase_rec_devs <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$phase_N1_devs <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$phase_q <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$phase_q_devs <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$phase_SR_scalar <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$phase_steepness <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
 
 
   ### CVs and Lambdas
   # .... related to recruitment
-  dat$recruit_cv <- as.matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years, quiet=quiet_opt))
+  dat$recruit_cv <- as.matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years, quiet=quiet))
   # .... related to catch, discrads and indices
-  dat$lambda_index <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
-  dat$lambda_catch <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet_opt)
-  dat$lambda_discard <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet_opt)
-  dat$catch_cv <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_fleets, quiet=quiet_opt), dat$n_years, dat$n_fleets, byrow = TRUE)
-  dat$discard_cv <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_fleets, quiet=quiet_opt), dat$n_years, dat$n_fleets, byrow = TRUE)
-  dat$catch_Neff <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_fleets, quiet=quiet_opt), dat$n_years, dat$n_fleets, byrow = TRUE)
-  dat$discard_Neff <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_fleets, quiet=quiet_opt), dat$n_years, dat$n_fleets, byrow = TRUE)
+  dat$lambda_index <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet)
+  dat$lambda_catch <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet)
+  dat$lambda_discard <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet)
+  dat$catch_cv <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_fleets, quiet=quiet), dat$n_years, dat$n_fleets, byrow = TRUE)
+  dat$discard_cv <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_fleets, quiet=quiet), dat$n_years, dat$n_fleets, byrow = TRUE)
+  dat$catch_Neff <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_fleets, quiet=quiet), dat$n_years, dat$n_fleets, byrow = TRUE)
+  dat$discard_Neff <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_years*dat$n_fleets, quiet=quiet), dat$n_years, dat$n_fleets, byrow = TRUE)
   # .... related to fishing mortality
-  dat$lambda_F1 <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet_opt)
-  dat$cv_F1 <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet_opt)
-  dat$lambda_F_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet_opt)
-  dat$cv_F_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet_opt)
+  dat$lambda_F1 <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet)
+  dat$cv_F1 <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet)
+  dat$lambda_F_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet)
+  dat$cv_F_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet)
   # .... related to abundance (and recruitment again)
-  dat$lambda_N1_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$cv_N1_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$lambda_rec_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$lambda_N1_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$cv_N1_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$lambda_rec_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
   # .... related to catchability
-  dat$lambda_q <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
-  dat$cv_q <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
-  dat$lambda_q_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
-  dat$cv_q_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
+  dat$lambda_q <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet)
+  dat$cv_q <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet)
+  dat$lambda_q_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet)
+  dat$cv_q_devs <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet)
   # .... related to S-R relationship
-  dat$lambda_steepness <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$cv_steepness <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$lambda_SR_scalar <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$cv_SR_scalar <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$lambda_steepness <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$cv_steepness <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$lambda_SR_scalar <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$cv_SR_scalar <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
 
 
   ### Initial guesses
-  dat$N1_flag <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$N1_flag <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
     # 1 for devs from exponential decline, 2 for devs from initial guesses
-  dat$N1_ini <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_ages, quiet=quiet_opt)
-  dat$F1_ini <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet_opt)
-  dat$q_ini <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet_opt)
-  dat$SR_scalar_type <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$N1_ini <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_ages, quiet=quiet)
+  dat$F1_ini <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet)
+  dat$q_ini <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = dat$n_indices, quiet=quiet)
+  dat$SR_scalar_type <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
     # 1 for R0, 0 for SSB0
-  dat$SR_scalar_ini <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$steepness_ini <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$Fmax <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$ignore_guesses <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$SR_scalar_ini <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$steepness_ini <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$Fmax <- scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$ignore_guesses <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
 
 
   ### Projections
-  dat$do_proj <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$dir_fleet <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet_opt)
-  dat$nfinalyear <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$do_proj <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$dir_fleet <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = dat$n_fleets, quiet=quiet)
+  dat$nfinalyear <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
   # .... number of years in projections
   n <- (dat$nfinalyear-dat$year1)-dat$n_years+1
   # .... projection data by year (if n>0)
-  if(n>0) { dat$proj_ini <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = n*5, quiet=quiet_opt), n, 5, byrow = TRUE) }  else
+  if(n>0) { dat$proj_ini <- matrix(scan(datf, what = double(), skip = dat.start[ind <- ind + 1], n = n*5, quiet=quiet), n, 5, byrow = TRUE) }  else
       dat$proj_ini <- matrix(nrow = 0, ncol = 5)
     # be careful here, may cause problems writing because no lines when final year of projection=last year in assessment
 
 
   ### MCMC
-  dat$doMCMC <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$MCMC_nyear_opt <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$doMCMC <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$MCMC_nyear_opt <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
     # 0=output nyear NAA, 1=output nyear+1 NAA
-  dat$MCMC_nboot <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$MCMC_nthin <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$MCMC_nseed <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$MCMC_nboot <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$MCMC_nthin <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$MCMC_nseed <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
   # .... agepro
-  dat$fill_R_opt <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$fill_R_opt <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
     # 1=SR, 2=geomean
-  dat$R_avg_start <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$R_avg_end <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$R_avg_start <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$R_avg_end <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
 
 
   ### Final loose ends
-  dat$make_R_file <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
-  dat$testval <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet_opt)
+  dat$make_R_file <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
+  dat$testval <- scan(datf, what = integer(), skip = dat.start[ind <- ind + 1], n = 1, quiet=quiet)
 
   if(dat$testval != -23456)  {stop("dat file not read in correctly because testval does not equal -23456")}
   if(dat$testval == -23456)  {print("Hooray!  Test value at end of file is correct.  dat file read in correctly by ReadASAP3DatFile.")}

--- a/man/ReadASAP3DatFile.Rd
+++ b/man/ReadASAP3DatFile.Rd
@@ -4,10 +4,12 @@
 \alias{ReadASAP3DatFile}
 \title{ReadASAP3DatFile}
 \usage{
-ReadASAP3DatFile(datf)
+ReadASAP3DatFile(datf, quiet=FALSE)
 }
 \arguments{
 \item{datf}{full path and name of dat file (including .dat suffix)}
+\item{quiet}{logical option passed to scan().}
+
 }
 \description{
 Read ASAP 3 dat file into R (thanks to Tim Miller for providing original version).


### PR DESCRIPTION
@cmlegault : I've added an optional "quiet" argument to ReadASAP3DatFile that is passed to scan()

default=FALSE, so fully backwards compatible. 
quiet=TRUE suppresses printing of results of scan()

This might only be useful to me...I'm reading in .dat files as part of a loop and using the console output occasionally to debug. Without "quiet", it's hard to figure out how far along in the loop I am.

```
# testing script
file_in<-file.path("your","path", "to", "examples", "simplelogistic.dat")
dat_file_OG <- ReadASAP3DatFile(file_in)
dat_file_noisy <- ReadASAP3DatFile(file_in, quiet=FALSE) 
dat_file_quiet <- ReadASAP3DatFile(file_in, quiet=TRUE) 

all.equal(dat_file_OG, dat_file_noisy)
all.equal(dat_file_OG, dat_file_quiet)
```